### PR TITLE
fix: replace stale uploadKotlin task name with uploadOSSRHToMavenCentralNexus

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           build-command: true
           check-command: true
-          deploy-command: ./gradlew uploadKotlin close || ./gradlew uploadKotlin close || ./gradlew uploadKotlin close
+          deploy-command: ./gradlew uploadOSSRHToMavenCentralNexus close || ./gradlew uploadOSSRHToMavenCentralNexus close || ./gradlew uploadOSSRHToMavenCentralNexus close
           java-version: 17
           should-run-codecov: false
           should-deploy: true

--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@ var publishCmd = `
 git tag -a -f \${nextRelease.version} \${nextRelease.version} -F CHANGELOG.md
 git push --force origin \${nextRelease.version} || exit 6
 ./gradlew shadowJar --parallel || ./gradlew shadowJar --parallel || exit 4
-./gradlew uploadKotlinOSSRHToMavenCentralNexus releaseStagingRepositoryOnMavenCentral --parallel || exit 5
+./gradlew uploadOSSRHToMavenCentralNexus releaseStagingRepositoryOnMavenCentral --parallel || exit 5
 ./gradlew publishAllPublicationsToGitHubRepository --continue || true
 `
 var config = require('semantic-release-preconfigured-conventional-commits');


### PR DESCRIPTION
## Summary

- `publish-on-central` v8 renamed its upload task to key off the publication name (`OSSRH`) instead of the project name (`Kotlin`). Two call sites still referenced the old names and fail at Gradle's task-resolution stage (before any network call):
  - `.github/workflows/built_and_test.yml`'s `test-deploy` job deploy-command: `uploadKotlin` → `uploadOSSRHToMavenCentralNexus`
  - `release.config.js`'s `publishCmd` (used by real `semantic-release` runs): `uploadKotlinOSSRHToMavenCentralNexus` → `uploadOSSRHToMavenCentralNexus`
- This is the third and last layer of the `publish-on-central` v8 upgrade break, found underneath #984/PR #985 and the Java 17 fix. Filed and handled separately (#986) since it touches the live release/publish command path.

Closes #986

## Test plan

- [x] `./gradlew uploadOSSRHToMavenCentralNexus --dry-run` resolves the full signing/staging/upload task graph (compile → sign → create staging repo → upload), confirming the task name is correct
- [x] `./gradlew close --dry-run` still resolves via Gradle's task-name abbreviation to `closeStagingRepositoryOnMavenCentral` — unaffected by this change
- [x] `./gradlew build` passes
- [ ] CI on this PR

Note per the issue: a green CI run here proves the task *resolves*, not that a full real upload succeeds (that also depends on live Maven Central credentials in CI secrets) — recommend reading the two-line diff directly given it's on the real release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)