### PR TITLE
fix: migrate Maven Central publishing from OSSRH to Central Portal

### DIFF
--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -54,7 +54,10 @@ jobs:
         with:
           build-command: true
           check-command: true
-          deploy-command: ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication --stacktrace
+          deploy-command: >-
+            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication --stacktrace ||
+            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication --stacktrace ||
+            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication --stacktrace
           java-version: 17
           should-run-codecov: false
           should-deploy: true

--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -54,10 +54,7 @@ jobs:
         with:
           build-command: true
           check-command: true
-          deploy-command: >-
-            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication ||
-            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication ||
-            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication
+          deploy-command: ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication --stacktrace
           java-version: 17
           should-run-codecov: false
           should-deploy: true

--- a/.github/workflows/built_and_test.yml
+++ b/.github/workflows/built_and_test.yml
@@ -41,23 +41,27 @@ jobs:
         with:
           build-command: true
           check-command: |
-            ./gradlew tasks | grep releaseStagingRepositoryOnMavenCentral
-            ./gradlew tasks | grep closeStagingRepositoryOnMavenCentral
+            ./gradlew tasks | grep zipMavenCentralPortalPublication
+            ./gradlew tasks | grep releaseMavenCentralPortalPublication
           should-run-codecov: false
           should-deploy: false
           should-validate-wrapper: false
       - uses: DanySK/build-check-deploy-gradle-action@4.0.33
         if: contains(github.repository, 'Kotlin2PlantUML') && contains('push workflow_dispatch', github.event_name)
+        env:
+          MAVEN_CENTRAL_PORTAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_PORTAL_USERNAME }}
+          MAVEN_CENTRAL_PORTAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PORTAL_PASSWORD }}
         with:
           build-command: true
           check-command: true
-          deploy-command: ./gradlew uploadOSSRHToMavenCentralNexus close || ./gradlew uploadOSSRHToMavenCentralNexus close || ./gradlew uploadOSSRHToMavenCentralNexus close
+          deploy-command: >-
+            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication ||
+            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication ||
+            ./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication
           java-version: 17
           should-run-codecov: false
           should-deploy: true
           should-validate-wrapper: false
-          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           signing-key: ${{ secrets.SIGNING_KEY }}
           signing-password: ${{ secrets.SIGNING_PASSWORD }}
   release:
@@ -82,6 +86,8 @@ jobs:
       - uses: DanySK/build-check-deploy-gradle-action@4.0.33
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          MAVEN_CENTRAL_PORTAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_PORTAL_USERNAME }}
+          MAVEN_CENTRAL_PORTAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PORTAL_PASSWORD }}
         with:
           java-version: 17
           build-command: true
@@ -93,8 +99,6 @@ jobs:
           should-deploy: true
           should-validate-wrapper: false
           github-token: ${{ secrets.GH_TOKEN }}
-          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           signing-key: ${{ secrets.SIGNING_KEY }}
           signing-password: ${{ secrets.SIGNING_PASSWORD }}
   success:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,6 +102,18 @@ tasks.withType<ShadowJar> {
     archiveVersion.set("")
 }
 
+afterEvaluate {
+    // Shadow's "shadowRuntimeElements" variant collides with the plain jar in the OSSRH
+    // publication (both end up with extension 'jar' and no classifier), which fails
+    // Maven Central Portal publication validation. Excluded per publish-on-central's docs:
+    // https://github.com/DanySK/publish-on-central#excluding-large-shadowjars--uberjars--fatjars
+    components.withType<AdhocComponentWithVariants>().named("java").configure {
+        withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) {
+            skip()
+        }
+    }
+}
+
 tasks.getByName<Test>("test") {
     useJUnitPlatform()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-qa = { id = "org.danilopianini.gradle-kotlin-qa", version = "0.97.0" }
-publicOnCentral = { id = "org.danilopianini.publish-on-central", version = "8.0.7" }
+publicOnCentral = { id = "org.danilopianini.publish-on-central", version = "9.1.1" }
 dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
 shadowJar = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 semanticVersioning = { id = "org.danilopianini.git-sensitive-semantic-versioning", version = "6.0.2" }

--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@ var publishCmd = `
 git tag -a -f \${nextRelease.version} \${nextRelease.version} -F CHANGELOG.md
 git push --force origin \${nextRelease.version} || exit 6
 ./gradlew shadowJar --parallel || ./gradlew shadowJar --parallel || exit 4
-./gradlew uploadOSSRHToMavenCentralNexus releaseStagingRepositoryOnMavenCentral --parallel || exit 5
+./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication --parallel || exit 5
 ./gradlew publishAllPublicationsToGitHubRepository --continue || true
 `
 var config = require('semantic-release-preconfigured-conventional-commits');


### PR DESCRIPTION
## Summary

- Sonatype fully sunset legacy OSSRH (`s01.oss.sonatype.org`) on 2025-06-30 — the reason every deploy attempt has been failing with HTTP 402 at `createStagingRepositoryOnMavenCentral`, even after #984/#986 fixed the earlier layers of the same `publish-on-central` v8 upgrade. Migrates publishing to Sonatype's Central Portal, which the plugin has supported since v7.0.0.
- Bump `org.danilopianini.publish-on-central` 8.0.7 → **9.1.1** (not the latest 9.2.11 — bisected locally and confirmed 9.1.2+ requires a newer Kotlin/Gradle runtime than this repo's Gradle 8.14.5 wrapper provides; 9.1.1 is the latest version still compatible with it. Revisit once Gradle is bumped in Milestone 2). v9.0.0 also fully drops the now-permanently-dead Nexus tasks.
- Replace the Nexus task pipeline with the Portal pipeline (`publishAllPublicationsToProjectLocalRepository` → `zipMavenCentralPortalPublication` → `releaseMavenCentralPortalPublication`) in both the CI workflow and `release.config.js`'s `publishCmd`.
- Wire `MAVEN_CENTRAL_PORTAL_USERNAME`/`PASSWORD` as plain env vars (the reusable `build-check-deploy-gradle-action` has no dedicated Portal-credential inputs) and drop the now-unused `maven-central-username`/`password` inputs that carried the old OSSRH creds.

Closes #988

## ⚠️ Action required before this actually deploys

New GitHub secrets are needed: `MAVEN_CENTRAL_PORTAL_USERNAME` / `MAVEN_CENTRAL_PORTAL_PASSWORD`, generated from a **Portal user token** at central.sonatype.com/usertoken — this is *not* your old OSSRH username/password. Also worth confirming the `io.github.kelvindev15` namespace shows up under central.sonatype.com/publishing/namespaces (Sonatype auto-migrated existing namespaces, but worth checking).

## Test plan

- [x] Verified task names and credential env-var names/fallback order directly against the plugin's own source/README at tag 9.1.1
- [x] `./gradlew build` passes
- [x] Full Portal task chain (`publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication --dry-run`) resolves cleanly
- [x] Real (non-dry-run) local attempt gets past compile/sign-setup/zip, stopping only at the signing step (expected — no local PGP key configured outside CI)
- [ ] CI on this PR
- [ ] A real deploy, once the new Portal secrets are added — this is the one thing that can't be verified without live credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)