### PR TITLE
chore(deps): update commons-cli to v1.11.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref =
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.195" }
 jGraph = { module = "org.jgrapht:jgrapht-core", version = "1.5.3" }
-common-cli = { module = "commons-cli:commons-cli", version = "1.9.0" }
+common-cli = { module = "commons-cli:commons-cli", version = "1.11.0" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jUnit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jUnit" }
 

--- a/src/main/kotlin/io/github/kelvindev15/kotlin2plantuml/Main.kt
+++ b/src/main/kotlin/io/github/kelvindev15/kotlin2plantuml/Main.kt
@@ -5,9 +5,9 @@ import io.github.kelvindev15.kotlin2plantuml.plantuml.Configuration
 import io.github.kelvindev15.kotlin2plantuml.utils.DefaultScanConfiguration
 import io.github.kelvindev15.kotlin2plantuml.utils.ReflectUtils
 import org.apache.commons.cli.DefaultParser
-import org.apache.commons.cli.HelpFormatter
 import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
+import org.apache.commons.cli.help.HelpFormatter
 import java.io.File
 import kotlin.reflect.KVisibility
 import kotlin.system.exitProcess
@@ -89,7 +89,10 @@ fun main(args: Array<String>) {
             maxMethodVisibility = toVisibility(commandLine.getOptionValue(methodVisibility)),
         )
     if (commandLine.hasOption(help)) {
-        HelpFormatter().printHelp("java -jar kotlin2plantuml.jar full.class.name [...options]", options)
+        HelpFormatter
+            .builder()
+            .get()
+            .printHelp("java -jar kotlin2plantuml.jar full.class.name [...options]", null, options, null, false)
         exitProcess(0)
     }
     require(args.isNotEmpty()) {


### PR DESCRIPTION
Part of Milestone 2 (#993). Supersedes #804.

Bumps `commons-cli` 1.9.0 → 1.11.0. This version deprecated `org.apache.commons.cli.HelpFormatter`'s no-arg constructor (and the whole class, in favor of the new `org.apache.commons.cli.help.HelpFormatter`), which broke the `-Werror` compile step. Migrated `Main.kt` to the new builder-based API.

## Test plan
- [x] `./gradlew check` passes locally (compile, tests, ktlint, detekt)
- [ ] CI green