### PR TITLE
chore(deps): update dokka to v2.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-qa = { id = "org.danilopianini.gradle-kotlin-qa", version = "0.97.0" }
 publicOnCentral = { id = "org.danilopianini.publish-on-central", version = "9.1.1" }
-dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
+dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 shadowJar = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 semanticVersioning = { id = "org.danilopianini.git-sensitive-semantic-versioning", version = "6.0.2" }
 


### PR DESCRIPTION
Part of Milestone 2 (#993). Supersedes #861.

Bumps Dokka 2.0.0 → 2.2.0. Dokka's V1-mode compatibility shim (deprecated since 2.0.0) is gone by default at this version, which broke `javadocJar` (wired through the now-disabled legacy `dokkaHtml` alias via `withJavadocJar()`, called by publish-on-central). Opted into full V2 mode (`org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled` in `gradle.properties`), which makes Dokka wire `javadocJar` directly to its native `dokkaGeneratePublicationHtml` task instead.

Verified locally:
- `./gradlew check` passes
- `./gradlew javadocJar` produces a correct, non-duplicated jar
- `./gradlew publishAllPublicationsToProjectLocalRepository` gets past doc generation cleanly (fails only at signing, as expected with no local signing key)

## Test plan
- [x] `./gradlew check` passes locally
- [ ] CI green