### PR TITLE
chore(deps): update plugin gradle-kotlin-qa to v1.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-qa = { id = "org.danilopianini.gradle-kotlin-qa", version = "0.97.0" }
+kotlin-qa = { id = "org.danilopianini.gradle-kotlin-qa", version = "1.9.0" }
 publicOnCentral = { id = "org.danilopianini.publish-on-central", version = "9.1.1" }
 dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
 shadowJar = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/src/main/kotlin/io/github/kelvindev15/kotlin2plantuml/plantuml/PlantUmlClass.kt
+++ b/src/main/kotlin/io/github/kelvindev15/kotlin2plantuml/plantuml/PlantUmlClass.kt
@@ -38,11 +38,17 @@ class PlantUmlClass(
                 .filter {
                     it.visibility?.let { visibility ->
                         when (it) {
-                            is KFunction<*> ->
+                            is KFunction<*> -> {
                                 !configuration.hideMethods && visibility.canShow(configuration.maxMethodVisibility)
-                            is KProperty<*> ->
+                            }
+
+                            is KProperty<*> -> {
                                 !configuration.hideFields && visibility.canShow(configuration.maxFieldVisibility)
-                            else -> false
+                            }
+
+                            else -> {
+                                false
+                            }
                         }
                     } ?: false
                 }.forEach {

--- a/src/test/kotlin/io/github/kelvindev15/kotlin2plantuml/test/sample/Car.kt
+++ b/src/test/kotlin/io/github/kelvindev15/kotlin2plantuml/test/sample/Car.kt
@@ -46,10 +46,10 @@ class Car<T, O, A : ComplexGeneric<T, O, A>> :
         TODO("Not yet implemented")
     }
 
-    @Suppress("UnusedPrivateMember")
+    @Suppress("UnusedPrivateProperty")
     private val privateField = ""
 
-    @Suppress("EmptyFunctionBlock", "UnusedPrivateMember")
+    @Suppress("EmptyFunctionBlock", "UnusedPrivateFunction")
     private fun privateMethod() {}
 
     @Suppress("UnusedPrivateMember")


### PR DESCRIPTION
Part of Milestone 2 (#993). Supersedes #885, #928.

Bumps `gradle-kotlin-qa` 0.97.0 → 1.9.0 (jumped straight to latest 1.x rather than stopping at the intermediate 0.101.1 Renovate PR, per the milestone's "push through all majors" plan).

This pulls in an updated ktlint (new rule requires braces on `when` entries once any branch in the block is multi-line/braced) and an updated detekt (split `UnusedPrivateMember` into `UnusedPrivateProperty` / `UnusedPrivateFunction`). Changes:
- Reformatted the `when` block in `PlantUmlClass.kt` via `./gradlew ktlintFormat` (mechanical, no behavior change)
- Updated `@Suppress` annotations on the `Car.kt` test fixture to the renamed detekt rule IDs

## Test plan
- [x] `./gradlew check` passes locally
- [ ] CI green