### PR TITLE
chore(deps): update plugin git-sensitive-semantic-versioning to v7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,6 @@ gitSemVer {
     buildMetadataSeparator.set("+")
     distanceCounterRadix.set(36) // The radix for the commit-distance counter. Must be in the 2-36 range.
     versionPrefix.set("")
-    assignGitSemanticVersion()
 }
 
 publishOnCentral {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ kotlin-qa = { id = "org.danilopianini.gradle-kotlin-qa", version = "0.97.0" }
 publicOnCentral = { id = "org.danilopianini.publish-on-central", version = "9.1.1" }
 dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
 shadowJar = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
-semanticVersioning = { id = "org.danilopianini.git-sensitive-semantic-versioning", version = "6.0.2" }
+semanticVersioning = { id = "org.danilopianini.git-sensitive-semantic-versioning", version = "7.0.24" }
 
 [bundles]
 kotlin = [ "kotlin-reflect", "kotlin-stdlib" ]


### PR DESCRIPTION
Part of Milestone 2 (#993). Supersedes #825.

Bumps `git-sensitive-semantic-versioning` v6.0.2 → v7.0.24. v7 removed `assignGitSemanticVersion()`: `project.version` is now computed and assigned automatically/lazily from the `gitSemVer { ... }` extension once configured, so the explicit call is unresolvable and unnecessary. Removed it; verified `./gradlew properties` still reports a correctly computed version (`3.0.16-devfz+7cbd1e3`).

## Test plan
- [x] `./gradlew check` passes locally
- [x] `./gradlew properties` shows correctly computed `version`
- [ ] CI green