### PR TITLE
chore(deps): update Gradle wrapper to v9.7.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,8 @@ val githubUser = "Kelvindev15"
 
 if (System.getenv("CI") == true.toString()) {
     signing {
-        val signingKey: String? by project
-        val signingPassword: String? by project
+        val signingKey = project.findProperty("signingKey") as String?
+        val signingPassword = project.findProperty("signingPassword") as String?
         useInMemoryPgpKeys(signingKey, signingPassword)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-qa = { id = "org.danilopianini.gradle-kotlin-qa", version = "1.9.0" }
 publicOnCentral = { id = "org.danilopianini.publish-on-central", version = "9.1.1" }
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
-shadowJar = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+shadowJar = { id = "com.gradleup.shadow", version = "9.6.1" }
 semanticVersioning = { id = "org.danilopianini.git-sensitive-semantic-versioning", version = "7.0.24" }
 
 [bundles]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Part of Milestone 2 (#993). Supersedes #801. Landed last per the milestone plan, since it has the widest blast radius.

Bumps the Gradle wrapper 8.14.5 → 9.7.1. Two breaking changes required fixing:

1. **Shadow plugin was Gradle-9-incompatible.** `com.github.johnrengelman.shadow` 8.1.1 is unmaintained; its `ShadowApplicationPlugin` sets `CopySpec.fileMode`, which Gradle 9 removed. Migrated to the plugin's maintained successor, `com.gradleup.shadow` 9.6.1 (same task/API surface as before — only the plugin ID and Maven coordinates changed).
2. **Deprecated Kotlin DSL property-delegate syntax.** `val signingKey: String? by project` is deprecated and slated for removal in Gradle 10. Replaced with `project.findProperty("signingKey") as String?`.

Verified locally:
- `./gradlew check` passes
- `java -jar build/libs/kotlin2plantuml.jar --help` works (shadow fat-jar smoke test)
- `./gradlew publishAllPublicationsToProjectLocalRepository` gets through doc/POM/metadata generation cleanly, including the existing shadowRuntimeElements-variant-collision workaround from #991, failing only at signing (expected, no local signing key)

Remaining `Deprecated Gradle features ... incompatible with Gradle 10` warnings come from third-party plugins (gradle-kotlin-qa's internal use of `by registering` and `ReportingExtension.file()`), not this project's own build script.

## Test plan
- [x] `./gradlew check` passes locally
- [x] shadow fat-jar smoke test passes
- [x] local publish dry-run reaches signing step cleanly
- [ ] CI green