### PR TITLE
chore(deps): update plugin publiconcentral to v9.2.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-qa = { id = "org.danilopianini.gradle-kotlin-qa", version = "1.9.0" }
-publicOnCentral = { id = "org.danilopianini.publish-on-central", version = "9.1.1" }
+publicOnCentral = { id = "org.danilopianini.publish-on-central", version = "9.2.11" }
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 shadowJar = { id = "com.gradleup.shadow", version = "9.6.1" }
 semanticVersioning = { id = "org.danilopianini.git-sensitive-semantic-versioning", version = "7.0.24" }


### PR DESCRIPTION
Part of Milestone 2 (#993). Supersedes #992, #771. Last item in the backlog, landed after Gradle 9 (#998) as planned.

Bumps `publish-on-central` 9.1.1 → 9.2.11 (latest). During #988 this was deliberately capped at 9.1.1 after bisecting a `NoClassDefFoundError: kotlin/coroutines/jvm/internal/SpillingKt` failure to plugin versions >= 9.1.2, which bumped the plugin's internal Kotlin dependency to 2.2.0 (per its changelog) — a runtime requirement Gradle 8.14.5 couldn't satisfy. Now that Gradle is on 9.7.1, that failure no longer reproduces.

Verified locally:
- `./gradlew check` passes
- `./gradlew publishAllPublicationsToProjectLocalRepository` gets through doc/POM/metadata generation cleanly, failing only at signing (expected, no local signing key)

This closes out the full Milestone 2 dependency backlog (#993).

## Test plan
- [x] `./gradlew check` passes locally
- [x] local publish dry-run reaches signing step cleanly
- [ ] CI green